### PR TITLE
PISA attempting to run ALPHA tests

### DIFF
--- a/install_simple_scalar.sh
+++ b/install_simple_scalar.sh
@@ -98,7 +98,7 @@ cd ../simplesim*
 make config-pisa
 make
 # You can check that SimpleScalar (not the toolchain) works with the command-line:
-# ./sim-safe tests-alpha/bin/test-math
+# ./sim-safe tests-pisa/bin.little/test-math
 
 
 cd ../


### PR DESCRIPTION
Running the tests found here:

https://github.com/sdenel/How-to-install-SimpleScalar-on-Ubuntu/blob/ed281079d835046cd902987809e8028325fa009c/install_simple_scalar.sh#L101

Results in the following:
`fatal: PISA simulator cannot run Alpha binary 'tests-alpha/bin/test-math'`

The proper test I believe should be
`
./sim-safe tests-pisa/bin.little/test-math
`
which runs and prints the test:
>sim: ** starting functional simulation **
>pow(12.0, 2.0) == 144.000000
>pow(10.0, 3.0) == 1000.000000
>pow(10.0, -3.0) == 0.001000
>str: 123.456
>x: 123.000000
>str: 123.456
>x: 123.456000
>str: 123.456
>x: 123.456000
>123.456 123.456000 123 1000
>sinh(2.0) = 3.62686
>sinh(3.0) = 10.01787
>h=3.60555
>atan2(3,2) = 0.98279
>pow(3.60555,4.0) = 169
>169 / exp(0.98279 * 5) = 1.24102
>3.93117 + 5*log(3.60555) = 10.34355
>cos(10.34355) = -0.6068,  sin(10.34355) = -0.79486
>x     0.5x
>x0.5     x
>x   0.5x
>-1e-17 != -1e-17 Worked!
